### PR TITLE
Add When to use a Symfony Messenger component

### DIFF
--- a/playbooks/symfony/README.md
+++ b/playbooks/symfony/README.md
@@ -1,0 +1,7 @@
+<!-- prettier-ignore-start -->
+<!-- start_toc -->
+| Title | Overview |
+|---|---|
+| [When to use a Symfony Messenger component 🚚](/playbooks/symfony/symfony-messenger.md#readme) | A brief guideline on when is the right time to use a Symfony Messenger component |
+<!-- end_toc -->
+<!-- prettier-ignore-end -->

--- a/playbooks/symfony/README.md
+++ b/playbooks/symfony/README.md
@@ -2,6 +2,6 @@
 <!-- start_toc -->
 | Title | Overview |
 |---|---|
-| [When to use a Symfony Messenger component 🚚](/playbooks/symfony/symfony-messenger.md#readme) | A brief guideline on when is the right time to use a Symfony Messenger component |
+| [When to use a Symfony Messenger component 🚚](/playbooks/symfony/symfony-messenger.md#readme) | A brief guideline on situations where Symfony Messenger component could be used |
 <!-- end_toc -->
 <!-- prettier-ignore-end -->

--- a/playbooks/symfony/symfony-messenger.md
+++ b/playbooks/symfony/symfony-messenger.md
@@ -7,7 +7,7 @@ Symfony Messenger is a very powerful component that allows you to implement some
 PHP/Symfony projects that are usually non-concurrent.
 
 More info about it can be found in
-[official documentation.](https://symfony.com/doc/current/components/messenger.html) A really nice tutorial can ba
+[official documentation.](https://symfony.com/doc/current/components/messenger.html) A really nice tutorial can be
 found on [Symfonycasts.](https://symfonycasts.com/screencast/messenger) And we also have an internal education
 recorded from Week #48 (if you don't know where to find it, contact your nearest team-lead).  
 If you are wondering how to notify the client when concurrent job has been finished, take a look at  

--- a/playbooks/symfony/symfony-messenger.md
+++ b/playbooks/symfony/symfony-messenger.md
@@ -28,3 +28,7 @@ your case matches any of it, you have the green light ✅.
     1. Your software is sending requests to the 3rd party API, but you have no control over the order in which the
        requests are being sent - i.e. one request might still be waiting for the response, in the meantime, another
        request has already received its response
+
+
+A list of projects that are already using Symfony Messenger component:
+- 🔒 [Pilot project](https://github.com/bornfight/yipac-backend)

--- a/playbooks/symfony/symfony-messenger.md
+++ b/playbooks/symfony/symfony-messenger.md
@@ -15,7 +15,7 @@ the [Mercure protocol and Symfony Mercure component](https://symfony.com/doc/cur
 
 ### When to use the Messenger component?
 
-If you are here because you want to know should you use the Messenger component, go through the cases below, and if
+If you are here because you want to know if you should  use the Messenger component, go through the cases below, and if
 your case matches any of it, you have the green light ✅.
 
 #### There are two general cases when you might want to use Messenger component:

--- a/playbooks/symfony/symfony-messenger.md
+++ b/playbooks/symfony/symfony-messenger.md
@@ -1,0 +1,30 @@
+---
+title: When to use a Symfony Messenger component 🚚
+description: A brief guideline on when is the right time to use a Symfony Messenger component
+---
+
+Symfony Messenger is a very powerful component that allows you to implement some level of concurrency in your
+PHP/Symfony projects that are usually non-concurrent.
+
+More info about it can be found in
+[official documentation.](https://symfony.com/doc/current/components/messenger.html) A really nice tutorial can ba
+found on [Symfonycasts.](https://symfonycasts.com/screencast/messenger) And we also have an internal education
+recorded from Week #48 (if you don't know where to find it, contact your nearest team-lead).  
+If you are wondering how to notify the client when concurrent job has been finished, take a look at  
+the [Mercure protocol and Symfony Mercure component](https://symfony.com/doc/current/mercure.html)
+
+### When to use the Messenger component?
+
+If you are here because you want to know should you use the Messenger component, go through the cases below, and if
+your case matches any of it, you have the green light ✅.
+
+#### There are two general cases when you might want to use Messenger component:
+
+1. You would like to have your scripts running concurrently.
+    1. Your software is sending requests to the 3rd party API and you don't want to wait for the response.
+    2. Your software is doing some heavy-duty processing, and you'd hate to leave the client waiting for the
+       response.
+2. You would like to have the finest of the synchronicity possible.
+    1. Your software is sending requests to the 3rd party API, but you have no control over the order in which the
+       requests are being sent - i.e. one request might still be waiting for the response, in the meantime, another
+       request has already received its response

--- a/playbooks/symfony/symfony-messenger.md
+++ b/playbooks/symfony/symfony-messenger.md
@@ -1,6 +1,6 @@
 ---
 title: When to use a Symfony Messenger component 🚚
-description: A brief guideline on when is the right time to use a Symfony Messenger component
+description: A brief guideline on when to use a Symfony Messenger component
 ---
 
 Symfony Messenger is a very powerful component that allows you to implement some level of concurrency in your


### PR DESCRIPTION
Add a playbook document that provides a list of cases when Symfony Messenger component should be used.