### PR TITLE
Replace old internal blog's domain links with new ones

### DIFF
--- a/knowledge-base/internal-blog.md
+++ b/knowledge-base/internal-blog.md
@@ -27,7 +27,7 @@ something.
 
 And when someone asks a question you know is on the blog, you can just send them the link!
 
-You can find the [hall of fame here ](https://educations.dev/all-time-bloggers/ )🔒.
+You can find the [hall of fame here ](https://educations.dev/all-time-bloggers/)🔒.
 
 There are also some [topic up for grabs](https://educations.dev/topics-up-for-grabs/)🔒 that teammates
 want to read about, but don't exist yet.

--- a/knowledge-base/internal-blog.md
+++ b/knowledge-base/internal-blog.md
@@ -26,6 +26,3 @@ Don't be surprised if you use your own blog post every now and then, when you wa
 something.
 
 And when someone asks a question you know is on the blog, you can just send them the link!
-
-The rule is, when you take a topic from "up for grabs" and write about it, just put 2 new ones into the list,
-something YOU would want to read about. That way, we always have a place with ideas on topics.

--- a/knowledge-base/internal-blog.md
+++ b/knowledge-base/internal-blog.md
@@ -3,7 +3,7 @@ title: Internal blog
 description: How to use "DevEdu"
 ---
 
-Our [internal DevEdu blog](https://deghq.com/wordpress/devedu/) 🔒 is used only internally.
+Our [internal DevEdu blog](https://educations.dev/) 🔒 is used only internally.
 
 The idea is anything goes
 
@@ -26,11 +26,6 @@ Don't be surprised if you use your own blog post every now and then, when you wa
 something.
 
 And when someone asks a question you know is on the blog, you can just send them the link!
-
-You can find the [hall of fame here ](https://deghq.com/wordpress/devedu/all-time-bloggers/)🔒.
-
-There are also some [topic up for grabs](https://deghq.com/wordpress/devedu/topics-up-for-grabs/)🔒 that team mates
-want to read about, but don't exist yet.
 
 The rule is, when you take a topic from "up for grabs" and write about it, just put 2 new ones into the list,
 something YOU would want to read about. That way, we always have a place with ideas on topics.

--- a/knowledge-base/internal-blog.md
+++ b/knowledge-base/internal-blog.md
@@ -26,3 +26,11 @@ Don't be surprised if you use your own blog post every now and then, when you wa
 something.
 
 And when someone asks a question you know is on the blog, you can just send them the link!
+
+You can find the [hall of fame here ](https://educations.dev/all-time-bloggers/ )🔒.
+
+There are also some [topic up for grabs](https://educations.dev/topics-up-for-grabs/)🔒 that teammates
+want to read about, but don't exist yet.
+
+The rule is, when you take a topic from "up for grabs" and write about it, just put 2 new ones into the list,
+something YOU would want to read about. That way, we always have a place with ideas on topics.


### PR DESCRIPTION
Replaced old link for internal blog to the newer one - educations.dev.
Also, removed links to the older domain name which do not exist anymore.